### PR TITLE
Removing static, fixing checking entity existence

### DIFF
--- a/src/Console/Command/SeedCommand.php
+++ b/src/Console/Command/SeedCommand.php
@@ -37,7 +37,7 @@ final class SeedCommand extends Command
         $seeders = $locator->findSeeders($this->argument('class'));
 
         $executor->afterSeed(
-            static fn(SeederInterface $seeder) => $this->output->info(
+            fn(SeederInterface $seeder) => $this->output->info(
                 \sprintf('Seeding [%s] completed successfully.', $seeder::class)
             )
         );

--- a/src/Seeder/Executor.php
+++ b/src/Seeder/Executor.php
@@ -65,6 +65,10 @@ class Executor implements ExecutorInterface
             }
         }
 
+        if ($values === []) {
+            return true;
+        }
+
         return $this->orm->getRepository($entity)->findByPK(new Parameter($values)) === null;
     }
 }

--- a/tests/src/Functional/Driver/Common/Seeder/ExecutorTest.php
+++ b/tests/src/Functional/Driver/Common/Seeder/ExecutorTest.php
@@ -28,8 +28,11 @@ abstract class ExecutorTest extends TestCase
         $simplePk = UserFactory::new()->makeOne();
         $simplePk->id = 1;
 
+        $unInitializedPk = UserFactory::new()->makeOne();
+
         $this->assertTrue($method->invoke($executor, $compositePk));
         $this->assertTrue($method->invoke($executor, $simplePk));
+        $this->assertTrue($method->invoke($executor, $unInitializedPk));
     }
 
     public function testIsExists(): void

--- a/tests/src/Functional/Driver/MySQL/Seeder/ExecutorTest.php
+++ b/tests/src/Functional/Driver/MySQL/Seeder/ExecutorTest.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Functional\Driver\MySQL\Seeder;
+
+use Tests\Functional\Driver\Common\Seeder\ExecutorTest as CommonExecutorTest;
+
+/**
+ * @group driver
+ * @group driver-mysql
+ *
+ * Tests in conventional database (MySQL)
+ */
+final class ExecutorTest extends CommonExecutorTest
+{
+    public const ENV = [
+        'DEFAULT_DB' => 'mysql'
+    ];
+}

--- a/tests/src/Functional/TestCase.php
+++ b/tests/src/Functional/TestCase.php
@@ -4,9 +4,11 @@ declare(strict_types=1);
 
 namespace Tests\Functional;
 
+use Cycle\Database\DatabaseManager;
 use Spiral\Boot\Bootloader\ConfigurationBootloader;
 use Spiral\Cycle\Bootloader as CycleOrmBridge;
 use Spiral\DatabaseSeeder\Bootloader\DatabaseSeederBootloader;
+use Spiral\DatabaseSeeder\Database\DatabaseState;
 
 abstract class TestCase extends \Spiral\DatabaseSeeder\TestCase
 {
@@ -19,6 +21,15 @@ abstract class TestCase extends \Spiral\DatabaseSeeder\TestCase
         parent::tearDown();
 
         $this->cleanUpRuntimeDirectory();
+
+        $manager = $this->getContainer()->get(DatabaseManager::class);
+        foreach ($manager->database('mysql')->getTables() as $table) {
+            $schema = $table->getSchema();
+            $schema->declareDropped();
+            $schema->save();
+        }
+
+        DatabaseState::$migrated = false;
     }
 
     public function rootDirectory(): string

--- a/tests/src/Functional/TestCase.php
+++ b/tests/src/Functional/TestCase.php
@@ -22,14 +22,16 @@ abstract class TestCase extends \Spiral\DatabaseSeeder\TestCase
 
         $this->cleanUpRuntimeDirectory();
 
-        $manager = $this->getContainer()->get(DatabaseManager::class);
-        foreach ($manager->database('mysql')->getTables() as $table) {
-            $schema = $table->getSchema();
-            $schema->declareDropped();
-            $schema->save();
-        }
+        if (static::ENV['DEFAULT_DB'] === 'mysql') {
+            $manager = $this->getContainer()->get(DatabaseManager::class);
+            foreach ($manager->database('mysql')->getTables() as $table) {
+                $schema = $table->getSchema();
+                $schema->declareDropped();
+                $schema->save();
+            }
 
-        DatabaseState::$migrated = false;
+            DatabaseState::$migrated = false;
+        }
     }
 
     public function rootDirectory(): string

--- a/tests/src/Functional/TestCase.php
+++ b/tests/src/Functional/TestCase.php
@@ -22,7 +22,7 @@ abstract class TestCase extends \Spiral\DatabaseSeeder\TestCase
 
         $this->cleanUpRuntimeDirectory();
 
-        if (static::ENV['DEFAULT_DB'] === 'mysql') {
+        if (\array_key_exists('DEFAULT_DB', static::ENV) && static::ENV['DEFAULT_DB'] === 'mysql') {
             $manager = $this->getContainer()->get(DatabaseManager::class);
             foreach ($manager->database('mysql')->getTables() as $table) {
                 $schema = $table->getSchema();


### PR DESCRIPTION
1) Fixed bug with using $this in static function
`Using $this when not in object context in src\Console\Command\SeedCommand.php:40`

2) Fixed bug with checking entity existence in MySQL (added tests in MySQL). Empty IN (...) in query.
`SQLSTATE[42000]: Syntax error or access violation: 1064 You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near ')
LIMIT 1' at line 3 in vendor\cycle\database\src\Driver\MySQL\MySQLDriver.php:56`