### PR TITLE
Fixed wrong in assert functions `DatabaseAsserts::assertTableHasEntity` and `DatabaseAsserts::assertTableHas`

### DIFF
--- a/src/Database/Traits/DatabaseAsserts.php
+++ b/src/Database/Traits/DatabaseAsserts.php
@@ -49,7 +49,7 @@ trait DatabaseAsserts
             $select->where($where);
         }
 
-        static::assertTrue($select->count() >= 0, \sprintf('Record not found in the table [%s].', $table));
+        static::assertTrue($select->count() > 0, \sprintf('Record not found in the table [%s].', $table));
     }
 
     /** @param class-string $entity */

--- a/src/Database/Traits/DatabaseAsserts.php
+++ b/src/Database/Traits/DatabaseAsserts.php
@@ -77,6 +77,6 @@ trait DatabaseAsserts
             $select->where($where);
         }
 
-        static::assertTrue($select->count() >= 0, \sprintf('Entity [%s] not found.', $entity));
+        static::assertTrue($select->count() > 0, \sprintf('Entity [%s] not found.', $entity));
     }
 }


### PR DESCRIPTION
The condition in assert functions `DatabaseAsserts::assertTableHasEntity` and `DatabaseAsserts::assertTableHas` is incorrect. I changed the `>=` to `>`