### PR TITLE
Improved type information with psalm annotations on entity factory

### DIFF
--- a/src/Factory/AbstractFactory.php
+++ b/src/Factory/AbstractFactory.php
@@ -37,25 +37,25 @@ abstract class AbstractFactory implements FactoryInterface
     private array $entityStates = [];
 
     private function __construct(
-        private readonly array $replaces = []
+        private readonly array $replaces = [],
     ) {
         $this->faker = FakerFactory::create();
 
         $this->entityFactory = new Factory(
             new LaminasEntityFactory(
                 new ReflectionHydrator(),
-                new InstanceWithoutConstructorStrategy()
+                new InstanceWithoutConstructorStrategy(),
             ),
-            $this->faker
+            $this->faker,
         );
     }
 
+    /**
+     * In this method you should describe how to create an entity with the given definition.
+     *
+     * @return TEntity
+     */
     abstract public function makeEntity(array $definition): object;
-
-    /** @psalm-return class-string */
-    abstract public function entity(): string;
-
-    abstract public function definition(): array;
 
     public static function new(array $replace = []): static
     {
@@ -166,10 +166,12 @@ abstract class AbstractFactory implements FactoryInterface
     {
         $container = ContainerScope::getContainer();
         if ($container === null) {
-            throw new OutsideScopeException(\sprintf(
-                'The container is not available. Make sure [%s] method is running in the ContainerScope.',
-                __METHOD__
-            ));
+            throw new OutsideScopeException(
+                \sprintf(
+                    'The container is not available. Make sure [%s] method is running in the ContainerScope.',
+                    __METHOD__,
+                ),
+            );
         }
 
         /** @var EntityManagerInterface $em */
@@ -187,12 +189,12 @@ abstract class AbstractFactory implements FactoryInterface
         $this->entityFactory
             ->creationStrategy(
                 $this->entity(),
-                new ClosureStrategy(fn(string $class, array $data) => $this->makeEntity($data))
+                new ClosureStrategy(fn(string $class, array $data) => $this->makeEntity($data)),
             )
             ->define($this->entity(), $definition)
             ->states($this->entity(), $this->states);
 
-        foreach ($this->afterMake as $afterMakeCallable){
+        foreach ($this->afterMake as $afterMakeCallable) {
             $this->entityFactory->afterMaking($this->entity(), $afterMakeCallable);
         }
 

--- a/src/Factory/FactoryInterface.php
+++ b/src/Factory/FactoryInterface.php
@@ -4,23 +4,56 @@ declare(strict_types=1);
 
 namespace Spiral\DatabaseSeeder\Factory;
 
+/**
+ * @template TEntity of object
+ */
 interface FactoryInterface
 {
-    /** @psalm-return class-string */
+    /**
+     * Get the entity class name.
+     *
+     * @psalm-return class-string<TEntity>
+     */
     public function entity(): string;
-
-    public function definition(): array;
 
     public static function new(): static;
 
-    /** @psalm-param positive-int $amount */
+    /**
+     * Entity data definition. This data will be used to create an entity.
+     */
+    public function definition(): array;
+
+    /**
+     * How many entities should be created.
+     *
+     * @psalm-param positive-int $amount
+     */
     public function times(int $amount): self;
 
+    /**
+     * Create many entities with persisting them to the database.
+     *
+     * @return TEntity[]
+     */
     public function create(): array;
 
+    /**
+     * Create an entity with persisting it to the database.
+     *
+     * @return TEntity
+     */
     public function createOne(): object;
 
+    /**
+     * Make many entities without persisting them to the database.
+     *
+     * @return TEntity[]
+     */
     public function make(): array;
 
+    /**
+     * Make an entity without persisting it to the database.
+     * @return TEntity
+     */
     public function makeOne(): object;
 }


### PR DESCRIPTION
In this Pull Request, we have enriched the type information of  entity factory by integrating Psalm annotations. This enhancement facilitates developers by offering precise return type definitions.

Here's a snapshot of what has been done:

1. For a factory, you can now clearly define the return type. Here is an example utilizing `@implements FactoryInterface<...>` annotation:

```php
use Spiral\DatabaseSeeder\Factory\AbstractFactory;
use Spiral\DatabaseSeeder\Factory\FactoryInterface;
use App\Domain\User\Entity\User;

/**
 * @implements FactoryInterface<User>
 */
final class UserFactory extends AbstractFactory
{
   //...
}
```

With this annotation in place, your IDE will now provide suggestive autocomplete options, making the code interaction more intuitive and error-prone. 

Here are examples showing how IDE suggestions would appear post this update:

```php
$user = UserFactory::new()
            ->verified('secret')
            ->createOne();

$user->...
```

![image](https://github.com/spiral-packages/database-seeder/assets/773481/2da1fcf3-9214-4188-8993-1b4eaa65ac98)


This update aims to streamline the development process by providing clearer, type-informed interactions within the codebase.