### PR TITLE
Add TransactionStrategy, add helper trait

### DIFF
--- a/src/Database/Strategy/MigrationStrategy.php
+++ b/src/Database/Strategy/MigrationStrategy.php
@@ -18,10 +18,6 @@ use Spiral\Testing\TestCase;
  */
 class MigrationStrategy
 {
-    /**
-     * @param TestCase $testCase
-     * @param bool $createMigrations
-     */
     public function __construct(
         protected TestCase $testCase,
         protected bool $createMigrations = false
@@ -44,9 +40,7 @@ class MigrationStrategy
         $this->testCase->runCommand('migrate:rollback', ['--all' => true]);
 
         if ($this->createMigrations) {
-            $dir = $this->getMigrationsDirectory();
-            $this->testCase->cleanupDirectories($dir);
-            $this->testCase->getContainer()->get(FilesInterface::class)->ensureDirectory($dir, 0666);
+            $this->deleteMigrations();
         }
 
         DatabaseState::$migrated = false;
@@ -60,6 +54,18 @@ class MigrationStrategy
     public function enableCreationMigrations(): void
     {
         $this->createMigrations = true;
+    }
+
+    public function isCreateMigrations(): bool
+    {
+        return $this->createMigrations;
+    }
+
+    public function deleteMigrations(): void
+    {
+        $dir = $this->getMigrationsDirectory();
+        $this->testCase->cleanupDirectories($dir);
+        $this->testCase->getContainer()->get(FilesInterface::class)->ensureDirectory($dir, 0666);
     }
 
     protected function getMigrationsDirectory(): string

--- a/src/Database/Strategy/TransactionStrategy.php
+++ b/src/Database/Strategy/TransactionStrategy.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\DatabaseSeeder\Database\Strategy;
+
+use Cycle\Database\DatabaseInterface;
+use Spiral\Testing\TestCase;
+
+/**
+ * This strategy utilizes MigrationStrategy without executing migration and rolling back migration for each test
+ * but performs migration prior to running the first test. It wraps the test execution in a transaction before each
+ * test.
+ */
+class TransactionStrategy
+{
+    protected MigrationStrategy $migrationStrategy;
+
+    public function __construct(
+        protected TestCase $testCase,
+        ?MigrationStrategy $migrationStrategy = null
+    ) {
+        $this->migrationStrategy = $migrationStrategy ?? new MigrationStrategy($this->testCase);
+    }
+
+    public function begin(): void
+    {
+        $this->migrationStrategy->migrate();
+
+        if ($this->migrationStrategy->isCreateMigrations()) {
+            $this->migrationStrategy->deleteMigrations();
+        }
+
+        $this->testCase->getContainer()->get(DatabaseInterface::class)->getDriver()->beginTransaction();
+    }
+
+    public function rollback(): void
+    {
+        $this->testCase->getContainer()->get(DatabaseInterface::class)->getDriver()->rollbackTransaction();
+    }
+}

--- a/src/Database/Traits/Helper.php
+++ b/src/Database/Traits/Helper.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\DatabaseSeeder\Database\Traits;
+
+use Cycle\Database\DatabaseInterface;
+use Cycle\Database\DatabaseProviderInterface;
+use Cycle\Database\Driver\DriverInterface;
+use Cycle\ORM\ORMInterface;
+use Cycle\ORM\RepositoryInterface;
+use Spiral\DatabaseSeeder\Database\Cleaner;
+
+trait Helper
+{
+    private ?Cleaner $cleaner = null;
+
+    public function getDatabaseCleaner(): Cleaner
+    {
+        if ($this->cleaner === null) {
+            $this->cleaner = new Cleaner($this->getCurrentDatabaseProvider());
+        }
+
+        return $this->cleaner;
+    }
+
+    public function getCurrentDatabase(): DatabaseInterface
+    {
+        return $this->getContainer()->get(DatabaseInterface::class);
+    }
+
+    public function getCurrentDatabaseDriver(): DriverInterface
+    {
+        return $this->getCurrentDatabase()->getDriver();
+    }
+
+    public function getCurrentDatabaseProvider(): DatabaseProviderInterface
+    {
+        return $this->getContainer()->get(DatabaseProviderInterface::class);
+    }
+
+    public function getOrm(): ORMInterface
+    {
+        return $this->getContainer()->get(ORMInterface::class);
+    }
+
+    public function detachEntityFromIdentityMap(object $entity): void
+    {
+        $this->getOrm()->getHeap()->detach($entity);
+    }
+
+    public function cleanIdentityMap(): void
+    {
+        $this->getOrm()->getHeap()->clean();
+    }
+
+    public function getRepositoryFor(object|string $entity): RepositoryInterface
+    {
+        return $this->getOrm()->getRepository($entity);
+    }
+}

--- a/src/Database/Traits/Helper.php
+++ b/src/Database/Traits/Helper.php
@@ -7,6 +7,7 @@ namespace Spiral\DatabaseSeeder\Database\Traits;
 use Cycle\Database\DatabaseInterface;
 use Cycle\Database\DatabaseProviderInterface;
 use Cycle\Database\Driver\DriverInterface;
+use Cycle\ORM\EntityManagerInterface;
 use Cycle\ORM\ORMInterface;
 use Cycle\ORM\RepositoryInterface;
 use Spiral\DatabaseSeeder\Database\Cleaner;
@@ -44,6 +45,11 @@ trait Helper
         return $this->getContainer()->get(ORMInterface::class);
     }
 
+    public function getEntityManager(): EntityManagerInterface
+    {
+        return $this->getContainer()->get(EntityManagerInterface::class);
+    }
+
     public function detachEntityFromIdentityMap(object $entity): void
     {
         $this->getOrm()->getHeap()->detach($entity);
@@ -57,5 +63,10 @@ trait Helper
     public function getRepositoryFor(object|string $entity): RepositoryInterface
     {
         return $this->getOrm()->getRepository($entity);
+    }
+
+    public function persist(object $entity): void
+    {
+        $this->getEntityManager()->persist($entity)->run();
     }
 }

--- a/src/Database/Traits/Transaction.php
+++ b/src/Database/Traits/Transaction.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\DatabaseSeeder\Database\Traits;
+
+use Spiral\DatabaseSeeder\Database\Strategy\TransactionStrategy;
+
+trait Transaction
+{
+    private ?TransactionStrategy $transactionStrategy = null;
+
+
+    public function beginTransaction(): void
+    {
+        $this->beforeBeginTransaction();
+
+        $this->getTransactionStrategy()->begin();
+
+        $this->afterBeginTransaction();
+    }
+
+    public function rollbackTransaction(): void
+    {
+        $this->beforeRollbackTransaction();
+
+        $this->getTransactionStrategy()->rollback();
+
+        $this->afterRollbackTransaction();
+    }
+
+    protected function setUpTransaction(): void
+    {
+        $this->beginTransaction();
+    }
+
+    protected function tearDownTransaction(): void
+    {
+        $this->rollbackTransaction();
+    }
+
+    protected function getTransactionStrategy(): TransactionStrategy
+    {
+        if ($this->transactionStrategy === null) {
+            $this->transactionStrategy = new TransactionStrategy(testCase: $this);
+        }
+
+        return $this->transactionStrategy;
+    }
+
+    /**
+     * Perform any work before the database transaction has started
+     */
+    protected function beforeBeginTransaction(): void
+    {
+        // ...
+    }
+
+    /**
+     * Perform any work after the database transaction has started
+     */
+    protected function afterBeginTransaction(): void
+    {
+        // ...
+    }
+
+    /**
+     * Perform any work before rolling back the transaction
+     */
+    protected function beforeRollbackTransaction(): void
+    {
+        // ...
+    }
+
+    /**
+     * Perform any work after rolling back the transaction
+     */
+    protected function afterRollbackTransaction(): void
+    {
+        // ...
+    }
+}

--- a/src/Database/Traits/Transactions.php
+++ b/src/Database/Traits/Transactions.php
@@ -6,7 +6,7 @@ namespace Spiral\DatabaseSeeder\Database\Traits;
 
 use Spiral\DatabaseSeeder\Database\Strategy\TransactionStrategy;
 
-trait Transaction
+trait Transactions
 {
     private ?TransactionStrategy $transactionStrategy = null;
 

--- a/src/Database/Traits/Transactions.php
+++ b/src/Database/Traits/Transactions.php
@@ -29,12 +29,12 @@ trait Transactions
         $this->afterRollbackTransaction();
     }
 
-    protected function setUpTransaction(): void
+    protected function setUpTransactions(): void
     {
         $this->beginTransaction();
     }
 
-    protected function tearDownTransaction(): void
+    protected function tearDownTransactions(): void
     {
         $this->rollbackTransaction();
     }

--- a/src/Factory/AbstractFactory.php
+++ b/src/Factory/AbstractFactory.php
@@ -8,6 +8,7 @@ use Butschster\EntityFaker\EntityFactory\ClosureStrategy;
 use Butschster\EntityFaker\EntityFactory\InstanceWithoutConstructorStrategy;
 use Closure;
 use Cycle\ORM\EntityManagerInterface;
+use Cycle\ORM\ORMInterface;
 use Faker\Factory as FakerFactory;
 use Faker\Generator;
 use Laminas\Hydrator\ReflectionHydrator;
@@ -185,6 +186,8 @@ abstract class AbstractFactory implements FactoryInterface
             $em->persist($entity);
         }
         $em->run();
+
+        $container->get(ORMInterface::class)->getHeap()->clean();
     }
 
     /**

--- a/tests/src/Functional/Database/Strategy/MigrationStrategyTest.php
+++ b/tests/src/Functional/Database/Strategy/MigrationStrategyTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Tests\Functional\Database\Strategy;
 
-use Cycle\Database\DatabaseInterface;
 use Spiral\DatabaseSeeder\Database\Strategy\MigrationStrategy;
 use Spiral\DatabaseSeeder\Database\Traits\DatabaseAsserts;
 use Tests\Functional\TestCase;
@@ -51,7 +50,7 @@ final class MigrationStrategyTest extends TestCase
         $this->assertTable('composite_pk')->assertColumnExists('content');
         $this->assertTable('composite_pk')->assertEmpty();
 
-        $this->assertSame(0, $this->getContainer()->get(DatabaseInterface::class)->getDriver()->getTransactionLevel());
+        $this->assertSame(0, $this->getCurrentDatabaseDriver()->getTransactionLevel());
 
         $strategy->rollback();
 
@@ -60,7 +59,7 @@ final class MigrationStrategyTest extends TestCase
         $this->assertTable('users')->assertMissing();
         $this->assertTable('composite_pk')->assertMissing();
 
-        $this->assertSame(0, $this->getContainer()->get(DatabaseInterface::class)->getDriver()->getTransactionLevel());
+        $this->assertSame(0, $this->getCurrentDatabaseDriver()->getTransactionLevel());
     }
 
     public function testMigrateWithoutCreatingMigrations(): void
@@ -73,13 +72,13 @@ final class MigrationStrategyTest extends TestCase
         $strategy = new MigrationStrategy($this, false);
         $strategy->migrate();
 
-        $this->assertSame(0, $this->getContainer()->get(DatabaseInterface::class)->getDriver()->getTransactionLevel());
+        $this->assertSame(0, $this->getCurrentDatabaseDriver()->getTransactionLevel());
 
         $this->assertTable('comments')->assertMissing();
         $this->assertTable('posts')->assertMissing();
         $this->assertTable('users')->assertMissing();
         $this->assertTable('composite_pk')->assertMissing();
 
-        $this->assertSame(0, $this->getContainer()->get(DatabaseInterface::class)->getDriver()->getTransactionLevel());
+        $this->assertSame(0, $this->getCurrentDatabaseDriver()->getTransactionLevel());
     }
 }

--- a/tests/src/Functional/Database/Strategy/RefreshStrategyTest.php
+++ b/tests/src/Functional/Database/Strategy/RefreshStrategyTest.php
@@ -18,7 +18,7 @@ final class RefreshStrategyTest extends TestCase
 
     public function testRefreshStrategy(): void
     {
-        $db = $this->getContainer()->get(DatabaseInterface::class);
+        $db = $this->getCurrentDatabase();
         $schema = $db->table('users')->getSchema();
         $schema->primary('id');
         $schema->datetime('birthday')->nullable();
@@ -36,12 +36,12 @@ final class RefreshStrategyTest extends TestCase
 
         $this->assertTable('users')->assertCountRecords(5);
 
-        $strategy = new RefreshStrategy($this->cleaner);
+        $strategy = new RefreshStrategy($this->getDatabaseCleaner());
         $strategy->refresh();
 
         $this->assertTable('users')->assertEmpty();
 
-        $this->cleaner->dropTable('users');
+        $this->getDatabaseCleaner()->dropTable('users');
     }
 
     public function testRefreshStrategyWithExceptTable(): void
@@ -56,7 +56,7 @@ final class RefreshStrategyTest extends TestCase
         $this->assertTable('posts')->assertCountRecords(1);
         $this->assertTable('comments')->assertCountRecords(3);
 
-        $strategy = new RefreshStrategy($this->cleaner, except: ['comments', 'migrations']);
+        $strategy = new RefreshStrategy($this->getDatabaseCleaner(), except: ['comments', 'migrations']);
         $strategy->refresh();
 
         $this->assertTable('users')->assertEmpty();

--- a/tests/src/Functional/Database/Strategy/RefreshStrategyTest.php
+++ b/tests/src/Functional/Database/Strategy/RefreshStrategyTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Tests\Functional\Database\Strategy;
 
-use Cycle\Database\DatabaseInterface;
 use Spiral\DatabaseSeeder\Database\Strategy\MigrationStrategy;
 use Spiral\DatabaseSeeder\Database\Strategy\RefreshStrategy;
 use Spiral\DatabaseSeeder\Database\Traits\DatabaseAsserts;

--- a/tests/src/Functional/Database/Strategy/SQLFileStrategyTest.php
+++ b/tests/src/Functional/Database/Strategy/SQLFileStrategyTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Tests\Functional\Database\Strategy;
 
-use Cycle\Database\DatabaseProviderInterface;
 use Spiral\DatabaseSeeder\Database\Strategy\SqlFileStrategy;
 use Spiral\DatabaseSeeder\Database\Traits\DatabaseAsserts;
 use Tests\Functional\TestCase;

--- a/tests/src/Functional/Database/Strategy/SQLFileStrategyTest.php
+++ b/tests/src/Functional/Database/Strategy/SQLFileStrategyTest.php
@@ -19,14 +19,14 @@ final class SQLFileStrategyTest extends TestCase
 
         $strategy = new SqlFileStrategy(
             \dirname(__DIR__, 4) . '/app/database/sql/execute.sql',
-            $this->getContainer()->get(DatabaseProviderInterface::class)
+            $this->getCurrentDatabaseProvider()
         );
         $strategy->execute();
 
         $this->assertTable('users')->assertExists();
         $this->assertTable('users')->assertCountRecords(5);
 
-        $this->cleaner->dropTable('users');
+        $this->getDatabaseCleaner()->dropTable('users');
     }
 
     public function testExecuteAndDrop(): void
@@ -35,7 +35,7 @@ final class SQLFileStrategyTest extends TestCase
 
         $strategy = new SqlFileStrategy(
             \dirname(__DIR__, 4) . '/app/database/sql/execute.sql',
-            $this->getContainer()->get(DatabaseProviderInterface::class),
+            $this->getCurrentDatabaseProvider(),
             \dirname(__DIR__, 4) . '/app/database/sql/drop.sql',
         );
         $strategy->execute();

--- a/tests/src/Functional/Database/Strategy/TransactionStrategyTest.php
+++ b/tests/src/Functional/Database/Strategy/TransactionStrategyTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace src\Functional\Database\Strategy;
+namespace Tests\Functional\Database\Strategy;
 
 use Spiral\DatabaseSeeder\Database\Strategy\MigrationStrategy;
 use Spiral\DatabaseSeeder\Database\Strategy\TransactionStrategy;

--- a/tests/src/Functional/Database/Strategy/TransactionStrategyTest.php
+++ b/tests/src/Functional/Database/Strategy/TransactionStrategyTest.php
@@ -2,26 +2,36 @@
 
 declare(strict_types=1);
 
-namespace Tests\Functional\Database\Strategy;
+namespace src\Functional\Database\Strategy;
 
 use Cycle\Database\DatabaseInterface;
 use Spiral\DatabaseSeeder\Database\Strategy\MigrationStrategy;
+use Spiral\DatabaseSeeder\Database\Strategy\TransactionStrategy;
 use Spiral\DatabaseSeeder\Database\Traits\DatabaseAsserts;
 use Tests\Functional\TestCase;
 
-final class MigrationStrategyTest extends TestCase
+final class TransactionStrategyTest extends TestCase
 {
     use DatabaseAsserts;
 
-    public function testMigrateWithCreatingMigrations(): void
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+
+        $this->cleaner->dropTables();
+    }
+
+    public function testTransactionsWithCreatingMigrations(): void
     {
         $this->assertTable('comments')->assertMissing();
         $this->assertTable('posts')->assertMissing();
         $this->assertTable('users')->assertMissing();
         $this->assertTable('composite_pk')->assertMissing();
 
-        $strategy = new MigrationStrategy($this, true);
-        $strategy->migrate();
+        $strategy = new TransactionStrategy($this, new MigrationStrategy($this, true));
+        $strategy->begin();
+
+        $this->assertSame(1, $this->getContainer()->get(DatabaseInterface::class)->getDriver()->getTransactionLevel());
 
         $this->assertTable('comments')->assertExists();
         $this->assertTable('comments')->assertColumnExists('id');
@@ -51,35 +61,34 @@ final class MigrationStrategyTest extends TestCase
         $this->assertTable('composite_pk')->assertColumnExists('content');
         $this->assertTable('composite_pk')->assertEmpty();
 
-        $this->assertSame(0, $this->getContainer()->get(DatabaseInterface::class)->getDriver()->getTransactionLevel());
-
         $strategy->rollback();
 
-        $this->assertTable('comments')->assertMissing();
-        $this->assertTable('posts')->assertMissing();
-        $this->assertTable('users')->assertMissing();
-        $this->assertTable('composite_pk')->assertMissing();
-
         $this->assertSame(0, $this->getContainer()->get(DatabaseInterface::class)->getDriver()->getTransactionLevel());
+
+        $this->assertTable('comments')->assertExists();
+        $this->assertTable('posts')->assertExists();
+        $this->assertTable('users')->assertExists();
+        $this->assertTable('composite_pk')->assertExists();
     }
 
-    public function testMigrateWithoutCreatingMigrations(): void
+    public function testTransactionsWithoutCreatingMigrations(): void
     {
         $this->assertTable('comments')->assertMissing();
         $this->assertTable('posts')->assertMissing();
         $this->assertTable('users')->assertMissing();
         $this->assertTable('composite_pk')->assertMissing();
 
-        $strategy = new MigrationStrategy($this, false);
-        $strategy->migrate();
+        $strategy = new TransactionStrategy($this, new MigrationStrategy($this, false));
+        $strategy->begin();
 
-        $this->assertSame(0, $this->getContainer()->get(DatabaseInterface::class)->getDriver()->getTransactionLevel());
+        $this->assertSame(1, $this->getContainer()->get(DatabaseInterface::class)->getDriver()->getTransactionLevel());
 
         $this->assertTable('comments')->assertMissing();
         $this->assertTable('posts')->assertMissing();
         $this->assertTable('users')->assertMissing();
         $this->assertTable('composite_pk')->assertMissing();
 
+        $strategy->rollback();
         $this->assertSame(0, $this->getContainer()->get(DatabaseInterface::class)->getDriver()->getTransactionLevel());
     }
 }

--- a/tests/src/Functional/Database/Strategy/TransactionStrategyTest.php
+++ b/tests/src/Functional/Database/Strategy/TransactionStrategyTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace src\Functional\Database\Strategy;
 
-use Cycle\Database\DatabaseInterface;
 use Spiral\DatabaseSeeder\Database\Strategy\MigrationStrategy;
 use Spiral\DatabaseSeeder\Database\Strategy\TransactionStrategy;
 use Spiral\DatabaseSeeder\Database\Traits\DatabaseAsserts;
@@ -18,7 +17,7 @@ final class TransactionStrategyTest extends TestCase
     {
         parent::tearDown();
 
-        $this->cleaner->dropTables();
+        $this->getDatabaseCleaner()->dropTables();
     }
 
     public function testTransactionsWithCreatingMigrations(): void
@@ -31,7 +30,7 @@ final class TransactionStrategyTest extends TestCase
         $strategy = new TransactionStrategy($this, new MigrationStrategy($this, true));
         $strategy->begin();
 
-        $this->assertSame(1, $this->getContainer()->get(DatabaseInterface::class)->getDriver()->getTransactionLevel());
+        $this->assertSame(1, $this->getCurrentDatabaseDriver()->getTransactionLevel());
 
         $this->assertTable('comments')->assertExists();
         $this->assertTable('comments')->assertColumnExists('id');
@@ -63,7 +62,7 @@ final class TransactionStrategyTest extends TestCase
 
         $strategy->rollback();
 
-        $this->assertSame(0, $this->getContainer()->get(DatabaseInterface::class)->getDriver()->getTransactionLevel());
+        $this->assertSame(0, $this->getCurrentDatabaseDriver()->getTransactionLevel());
 
         $this->assertTable('comments')->assertExists();
         $this->assertTable('posts')->assertExists();
@@ -81,7 +80,7 @@ final class TransactionStrategyTest extends TestCase
         $strategy = new TransactionStrategy($this, new MigrationStrategy($this, false));
         $strategy->begin();
 
-        $this->assertSame(1, $this->getContainer()->get(DatabaseInterface::class)->getDriver()->getTransactionLevel());
+        $this->assertSame(1, $this->getCurrentDatabaseDriver()->getTransactionLevel());
 
         $this->assertTable('comments')->assertMissing();
         $this->assertTable('posts')->assertMissing();
@@ -89,6 +88,6 @@ final class TransactionStrategyTest extends TestCase
         $this->assertTable('composite_pk')->assertMissing();
 
         $strategy->rollback();
-        $this->assertSame(0, $this->getContainer()->get(DatabaseInterface::class)->getDriver()->getTransactionLevel());
+        $this->assertSame(0, $this->getCurrentDatabaseDriver()->getTransactionLevel());
     }
 }

--- a/tests/src/Functional/Database/Traits/HelperTest.php
+++ b/tests/src/Functional/Database/Traits/HelperTest.php
@@ -1,0 +1,113 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Functional\Database\Traits;
+
+use Cycle\Database\DatabaseInterface;
+use Cycle\Database\DatabaseProviderInterface;
+use Cycle\Database\Driver\DriverInterface;
+use Cycle\ORM\Heap\HeapInterface;
+use Cycle\ORM\ORMInterface;
+use Cycle\ORM\RepositoryInterface;
+use Spiral\DatabaseSeeder\Database\Cleaner;
+use Spiral\DatabaseSeeder\Database\Traits\Helper;
+use Tests\Functional\TestCase;
+
+final class HelperTest extends TestCase
+{
+    use Helper;
+
+    public function testGetDatabaseCleaner(): void
+    {
+        $cleaner = $this->getDatabaseCleaner();
+
+        $this->assertInstanceOf(Cleaner::class, $cleaner);
+        $this->assertSame($cleaner, $this->getDatabaseCleaner());
+    }
+
+    public function testGetCurrentDatabase(): void
+    {
+        $this->assertInstanceOf(DatabaseInterface::class, $this->getCurrentDatabase());
+    }
+
+    public function testGetCurrentDatabaseDriver(): void
+    {
+        $this->assertInstanceOf(DriverInterface::class, $this->getCurrentDatabaseDriver());
+    }
+
+    public function testGetCurrentDatabaseProvider(): void
+    {
+        $this->assertInstanceOf(DatabaseProviderInterface::class, $this->getCurrentDatabaseProvider());
+    }
+
+    public function testGetOrm(): void
+    {
+        $this->assertInstanceOf(ORMInterface::class, $this->getOrm());
+    }
+
+    public function testDetachEntityFromIdentityMap(): void
+    {
+        $heap = $this->createMock(HeapInterface::class);
+        $heap
+            ->expects($this->once())
+            ->method('detach')
+            ->with($entity = new \stdClass());
+
+        $orm = $this->createMock(ORMInterface::class);
+        $orm
+            ->expects($this->once())
+            ->method('getHeap')
+            ->willReturn($heap);
+        $this->getContainer()->bindSingleton(ORMInterface::class, $orm, true);
+
+        $this->detachEntityFromIdentityMap($entity);
+    }
+
+    public function testCleanIdentityMap(): void
+    {
+        $heap = $this->createMock(HeapInterface::class);
+        $heap
+            ->expects($this->once())
+            ->method('clean');
+
+        $orm = $this->createMock(ORMInterface::class);
+        $orm
+            ->expects($this->once())
+            ->method('getHeap')
+            ->willReturn($heap);
+        $this->getContainer()->bindSingleton(ORMInterface::class, $orm, true);
+
+        $this->cleanIdentityMap();
+    }
+
+    public function testGetRepositoryFor(): void
+    {
+        $repository = $this->createMock(RepositoryInterface::class);
+
+        $orm = $this->createMock(ORMInterface::class);
+        $orm
+            ->expects($this->once())
+            ->method('getRepository')
+            ->with($entity = new \stdClass())
+            ->willReturn($repository);
+        $this->getContainer()->bindSingleton(ORMInterface::class, $orm, true);
+
+        $this->assertSame($repository, $this->getRepositoryFor($entity));
+    }
+
+    public function testGetRepositoryForByString(): void
+    {
+        $repository = $this->createMock(RepositoryInterface::class);
+
+        $orm = $this->createMock(ORMInterface::class);
+        $orm
+            ->expects($this->once())
+            ->method('getRepository')
+            ->with('someEntity')
+            ->willReturn($repository);
+        $this->getContainer()->bindSingleton(ORMInterface::class, $orm, true);
+
+        $this->assertSame($repository, $this->getRepositoryFor('someEntity'));
+    }
+}

--- a/tests/src/Functional/Database/Traits/HelperTest.php
+++ b/tests/src/Functional/Database/Traits/HelperTest.php
@@ -7,6 +7,7 @@ namespace Tests\Functional\Database\Traits;
 use Cycle\Database\DatabaseInterface;
 use Cycle\Database\DatabaseProviderInterface;
 use Cycle\Database\Driver\DriverInterface;
+use Cycle\ORM\EntityManagerInterface;
 use Cycle\ORM\Heap\HeapInterface;
 use Cycle\ORM\ORMInterface;
 use Cycle\ORM\RepositoryInterface;
@@ -44,6 +45,11 @@ final class HelperTest extends TestCase
     public function testGetOrm(): void
     {
         $this->assertInstanceOf(ORMInterface::class, $this->getOrm());
+    }
+
+    public function testGetEntityManager(): void
+    {
+        $this->assertInstanceOf(EntityManagerInterface::class, $this->getEntityManager());
     }
 
     public function testDetachEntityFromIdentityMap(): void
@@ -109,5 +115,23 @@ final class HelperTest extends TestCase
         $this->getContainer()->bindSingleton(ORMInterface::class, $orm, true);
 
         $this->assertSame($repository, $this->getRepositoryFor('someEntity'));
+    }
+
+    public function testPersist(): void
+    {
+        $em = $this->createMock(EntityManagerInterface::class);
+
+        $em
+            ->expects($this->once())
+            ->method('persist')
+            ->with($entity = new \stdClass())
+            ->willReturnSelf();
+        $em
+            ->expects($this->once())
+            ->method('run');
+
+        $this->getContainer()->bindSingleton(EntityManagerInterface::class, $em, true);
+
+        $this->persist($entity);
     }
 }

--- a/tests/src/Functional/TestCase.php
+++ b/tests/src/Functional/TestCase.php
@@ -4,25 +4,15 @@ declare(strict_types=1);
 
 namespace Tests\Functional;
 
-use Cycle\Database\DatabaseProviderInterface;
 use Spiral\Boot\Bootloader\ConfigurationBootloader;
 use Spiral\Cycle\Bootloader as CycleOrmBridge;
 use Spiral\DatabaseSeeder\Bootloader\DatabaseSeederBootloader;
-use Spiral\DatabaseSeeder\Database\Cleaner;
 use Spiral\DatabaseSeeder\Database\Traits\DatabaseAsserts;
+use Spiral\DatabaseSeeder\Database\Traits\Helper;
 
 abstract class TestCase extends \Spiral\Testing\TestCase
 {
-    use DatabaseAsserts;
-
-    protected Cleaner $cleaner;
-
-    protected function setUp(): void
-    {
-        parent::setUp();
-
-        $this->cleaner = new Cleaner($this->getContainer()->get(DatabaseProviderInterface::class));
-    }
+    use DatabaseAsserts, Helper;
 
     protected function tearDown(): void
     {


### PR DESCRIPTION
## Features

### TransactionStrategy

A new **TransactionStrategy** has been implemented, utilizing the MigrationStrategy without executing migration and rollback for each test. Instead, it initiates migration before the first test execution and encapsulates each test's execution within a transaction before running it.

To use this strategy, add the `Spiral\DatabaseSeeder\Database\Traits\Transactions` trait to your base TestCase for tests that use a database.

```php
namespace Tests;

use Spiral\DatabaseSeeder\Database\Traits\Transactions;
use PHPUnit\Framework\TestCase;

abstract class DatabaseTestCase extends TestCase
{
    use Transactions;
}
```

### Helper

A `Spiral\DatabaseSeeder\Database\Traits\Helper` trait has been added, encompassing a set of useful testing methods:

- getDatabaseCleaner
- getCurrentDatabase
- getCurrentDatabaseDriver
- getCurrentDatabaseProvider
- getOrm
- getEntityManager
- detachEntityFromIdentityMap
- cleanIdentityMap
- getRepositoryFor
- persist

```php
use Spiral\DatabaseSeeder\Database\Traits\Helper;
use PHPUnit\Framework\TestCase;

class DatabaseTestCase extends TestCase
{
    use Helper;
    
    public function testAddUser(): void
    {
        $user = $this->userFactory->create(
            uuid: Uuid::uuid7(),
            email: 'user@site.com',
            name: 'John'
        );

        $this->persist($user);

        $user = $this->getRepositoryFor(User::class)->findByPK($user->uuid);

        $this->assertSame('user@site.com', $user->email);
        $this->assertSame('John', $user->name);
    }
}
```

The issue with Psalm is related to cycle/database.